### PR TITLE
Don't use https

### DIFF
--- a/recipes/_mac_os_x.rb
+++ b/recipes/_mac_os_x.rb
@@ -18,7 +18,7 @@
 #
 
 remote_file "#{Chef::Config[:file_cache_path]}/HipChat-2.5.6-87.zip" do
-  source 'https://downloads.hipchat.com.s3.amazonaws.com/osx/HipChat-2.5.6-87.zip'
+  source 'http://downloads.hipchat.com.s3.amazonaws.com/osx/HipChat-2.5.6-87.zip'
   checksum '8d764118f93efed5e6fc61dffa00da26d946a84a9e35ca2e07babdaa075760db'
   notifies :run, 'execute[unzip-hipchat]'
 end


### PR DESCRIPTION
Chef was failing due to the `https` url throwing a SSL cert mismatch. 
